### PR TITLE
Report active status when the charm is ready

### DIFF
--- a/reactive/kubeflow_tf_job_operator.py
+++ b/reactive/kubeflow_tf_job_operator.py
@@ -8,6 +8,11 @@ from charms.reactive import when, when_not, when_any
 from charms import layer
 
 
+@when('charm.kubeflow-tf-job-operator.started')
+def charm_ready():
+    layer.status.active('')
+
+
 @when_any('layer.docker-resource.tf-operator-image.changed',
           'config.changed')
 def update_image():


### PR DESCRIPTION
When charm has pushed the pod spec, report status as active so juju can correctly reflect the unit status when the container has started.