### PR TITLE
Add backwards-compatible CRD definitions

### DIFF
--- a/reactive/kubeflow_tf_job_operator.py
+++ b/reactive/kubeflow_tf_job_operator.py
@@ -83,6 +83,14 @@ def start_charm():
                 ],
             },
         ],
+        # Backwards compatibility for juju < 2.5.4
+        'customResourceDefinition': [{
+            'group': crd['spec']['group'],
+            'version': crd['spec']['version'],
+            'scope': crd['spec']['scope'],
+            'kind': crd['spec']['names']['kind'],
+            'validation': crd['spec']['validation']['openAPIV3Schema']['properties']['spec'],
+        }],
         'customResourceDefinitions': {
             crd['metadata']['name']: crd['spec'],
         },


### PR DESCRIPTION
Juju < 2.5.4 only understands this method of creating CRDs, but they're mutually ignored so we can have both methods in, and each Juju version will pick which one it understands.